### PR TITLE
Simplify test input helper

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -31,8 +31,7 @@ async function waitAfterOpenForm(page: Page) {
 async function fillTextInTestIdInput(page: Page, testId: string, value: string) {
   const field = page.getByTestId(testId).locator('input, textarea');
   await expect(field).toBeVisible();
-  await field.fill('');
-  await field.type(value);
+  await field.fill(value);
 }
 
 async function clickByTestId(page: Page, testId: string) {


### PR DESCRIPTION
## Summary
- simplify fillTextInTestIdInput by using a single fill call

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install chromium` *(fails: Download failed server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b8624a1d588329a7fdacbacba75653