### PR TITLE
refactor form load helper to avoid dynamic test IDs

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -24,7 +24,9 @@ async function waitForStableLoad(page: Page) {
 
 async function waitAfterOpenForm(page: Page) {
   await waitForStableLoad(page);
-  await expect(page.getByTestId('P785-C3-C1')).toBeVisible({ timeout: 15000 });
+  await expect(
+    page.getByRole('heading', { name: /Service provider/i })
+  ).toBeVisible({ timeout: 15000 });
 }
 
 async function fillTextInTestIdInput(page: Page, testId: string, value: string) {


### PR DESCRIPTION
## Summary
- wait for the initial form heading "Service provider" instead of a dynamic test id

## Testing
- `npm test` *(fails: Executable doesn't exist for Chromium)*
- `npx playwright install chromium` *(fails: Download failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b8725e9cf8832987def400ece5bcf1