### PR TITLE
feat: robust mat-select option lookup

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -180,7 +180,7 @@ async function setRadioByLabel(page: Page, groupLabel: string, optionText: strin
   await fallback.check();
 }
 
-async function clickNext(page: Page, buttonText: string = 'Next') {
+async function clickProceed(page: Page, buttonText: string = 'Next') {
   await page.getByRole('button', { name: buttonText }).click();
   await waitForStableLoad(page);
 }
@@ -270,7 +270,7 @@ test('End-to-end notification flow', async ({ page }) => {
   await fillTextByLabel(page, 'Scheduled end date of the posting', end);
 
   // Next to Notifier details
-  await clickNext(page);
+  await clickProceed(page);
 
   // SECTION 3 — Notifier details (person + company basics)
   await fillTextInTestIdInput(page, 'P785_NatuurlijkPersoon-Voornaam_1', requireEnv('NOTIFIER_FIRST_NAME'));
@@ -316,7 +316,7 @@ test('End-to-end notification flow', async ({ page }) => {
   await selectMatOptionByText(page, 'P785_NatuurlijkPersoon-Nationaliteit_1', 'Slovakia');
 
   // Next to Service recipient section
-  await clickNext(page);
+  await clickProceed(page);
 
   // SECTION 4 — Service recipient: type, KVK lookup, VAT, address, contact
   // Type of service recipient -> Company
@@ -352,7 +352,7 @@ test('End-to-end notification flow', async ({ page }) => {
   await fillTextInTestIdInput(page, 'P785_CP_Emailadres_1', requireEnv('SERVICE_RECIPIENT_EMAIL'));
 
   // Next to Work location section
-  await clickNext(page);
+  await clickProceed(page);
 
   // SECTION 5 — Address/place where work will be performed
   // Does the workplace in NL have a known address? -> Yes
@@ -379,7 +379,7 @@ test('End-to-end notification flow', async ({ page }) => {
   await selectMatOptionByText(page, 'P903_Werknemer-A1VerklaringLandIsoUitgifte_1', 'Slovakia (EEA)');
 
   // Go to summary
-  await clickNext(page, 'Go to summary');
+  await clickProceed(page, 'Go to summary');
 
   // SECTION 6 — Summary: confirm declaration and submit
   await page.getByTestId('P437_Melder-Akkoordverklaring_1').locator('input[type="checkbox"]').check();

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 
 // playwright.config note: ensure "use": { "baseURL": "" } if you prefer, but we use absolute URL here.
 
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, Locator } from '@playwright/test';
 import workLocation from '../work_location.json';
 
 // -------------------------------
@@ -41,11 +41,44 @@ async function clickByTestId(page: Page, testId: string) {
   await el.click();
 }
 
+async function selectMatOption(page: Page, optionText: string) {
+  // Try standard ARIA role lookup first
+  try {
+    const option = page.getByRole('option', { name: optionText, exact: true });
+    await option.waitFor({ state: 'visible', timeout: 1000 });
+    await option.click({ timeout: 1000 });
+    return;
+  } catch {}
+
+  // Fallback to mat-option element search
+  try {
+    const option = page.locator('mat-option', { hasText: optionText }).first();
+    await option.waitFor({ state: 'visible', timeout: 1000 });
+    await option.click({ timeout: 1000 });
+    return;
+  } catch {}
+
+  // Last resort: text lookup anywhere in option list
+  const fallback = page.locator(`text="${optionText}"`).first();
+  await fallback.waitFor({ state: 'visible', timeout: 1000 });
+  await fallback.click();
+}
+
 async function selectMatOptionByText(page: Page, testId: string, optionText: string) {
-  await clickByTestId(page, testId);
-  const option = page.getByRole('option', { name: optionText, exact: true });
-  await expect(option).toBeVisible();
-  await option.click();
+  try {
+    await clickByTestId(page, testId);
+  } catch {}
+
+  try {
+    await selectMatOption(page, optionText);
+    return;
+  } catch {}
+
+  // Fallback: open the mat-select trigger within the testId container
+  const container = page.getByTestId(testId);
+  const trigger = container.locator('.mat-mdc-select-trigger');
+  await trigger.click({ timeout: 1000 });
+  await selectMatOption(page, optionText);
 }
 
 async function setRadioByTestId(page: Page, groupTestId: string, valueTrueFalse: 'true'|'false') {
@@ -55,26 +88,96 @@ async function setRadioByTestId(page: Page, groupTestId: string, valueTrueFalse:
   await radio.check();
 }
 
+async function setInputValue(input: Locator, value: string) {
+  await input.click({ timeout: 1000 });
+  await input.fill(value);
+  if ((await input.inputValue()) !== value) {
+    await input.fill('');
+    await input.pressSequentially(value);
+  }
+  await expect(input).toHaveValue(value);
+  // Dismiss any date picker overlays that might block subsequent fields
+  await input.press('Tab').catch(() => {});
+}
+
 async function fillTextByLabel(page: Page, labelText: string, value: string) {
-  const field = page.getByLabel(labelText);
-  await expect(field).toBeVisible();
-  await field.fill(value);
+  // Try straightforward accessible lookup first
+  try {
+    const field = page.getByLabel(labelText, { exact: true });
+    await expect(field).toBeVisible({ timeout: 1000 });
+    await setInputValue(field, value);
+    return;
+  } catch {}
+
+  // Fallback: locate label manually and resolve its target input
+  const label = page.locator(`label:has-text("${labelText}")`).first();
+  await label.waitFor({ state: 'visible', timeout: 1000 });
+  const forAttr = await label.getAttribute('for');
+  let input = forAttr
+    ? page.locator(`#${forAttr}`)
+    : label.locator('xpath=..').locator('input, textarea').first();
+
+  await expect(input).toBeVisible({ timeout: 1000 });
+  await setInputValue(input, value);
 }
 
 async function selectMatOptionByLabel(page: Page, labelText: string, optionText: string) {
-  const field = page.getByLabel(labelText);
-  await expect(field).toBeVisible();
-  await field.click();
-  const option = page.getByRole('option', { name: optionText, exact: true });
-  await expect(option).toBeVisible();
-  await option.click();
+  // First attempt: use accessible label and option roles
+  try {
+    const field = page.getByLabel(labelText, { exact: true });
+    await field.click({ timeout: 1000 });
+    await selectMatOption(page, optionText);
+    return;
+  } catch {}
+
+  // Fallback: locate custom bq-select container by label text
+  try {
+    const container = page.locator('bq-select', {
+      has: page.locator(`label:has-text("${labelText}")`),
+    });
+    await container.waitFor({ state: 'visible', timeout: 1000 });
+    const trigger = container.locator('.mat-mdc-select-trigger');
+    await trigger.click({ timeout: 1000 });
+    await selectMatOption(page, optionText);
+    return;
+  } catch {}
+
+  // Last resort: click the label's "for" target and pick the option by text
+  const label = page.locator(`label:has-text("${labelText}")`).first();
+  await label.waitFor({ state: 'visible', timeout: 1000 });
+  const forAttr = await label.getAttribute('for');
+  if (forAttr) {
+    await page.locator(`#${forAttr}`).click({ timeout: 1000 });
+  } else {
+    await label.click({ timeout: 1000 });
+  }
+  await selectMatOption(page, optionText);
 }
 
 async function setRadioByLabel(page: Page, groupLabel: string, optionText: string) {
-  const group = page.getByRole('radiogroup', { name: groupLabel });
-  const option = group.getByLabel(optionText);
-  await expect(option).toBeVisible();
-  await option.check();
+  // Try accessible role-based lookup first
+  try {
+    const group = page.getByRole('radiogroup', { name: groupLabel });
+    const option = group.getByLabel(optionText, { exact: true });
+    await option.check({ timeout: 1000 });
+    return;
+  } catch {}
+
+  // Fallback: locate the custom radio container by label text and click the option label
+  try {
+    const container = page.locator('bq-radio-button', {
+      has: page.locator(`label:has-text("${groupLabel}")`),
+    });
+    await container.waitFor({ state: 'visible', timeout: 1000 });
+    const optionLabel = container.locator('label', { hasText: optionText }).first();
+    await optionLabel.click({ timeout: 1000 });
+    return;
+  } catch {}
+
+  // Last resort: rely on unique option label without group context
+  const fallback = page.getByLabel(optionText, { exact: true });
+  await expect(fallback).toBeVisible();
+  await fallback.check();
 }
 
 async function clickNext(page: Page, buttonText: string = 'Next') {


### PR DESCRIPTION
## Summary
- add generic option picker with fallbacks to handle non-standard mat-select overlays
- reuse option picker in select-by-label and select-by-testid helpers for resilient option selection
- harden text-by-label helper to reliably fill masked date inputs
- dismiss lingering date pickers after filling text fields to allow subsequent entries

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/ headless_shell)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68b88775da34832989e24ac1c32749b3