### PR TITLE
Handle missing KVK selection

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -352,9 +352,19 @@ test('End-to-end notification flow', async ({ page }) => {
   await page.getByRole('button', { name: 'Search in the Dutch trade register' }).click();
   await waitForStableLoad(page);
 
-  // Confirm result: click the "Select" action
-  await page.getByText('Select', { exact: true }).click();
-  await waitForStableLoad(page);
+  // Confirm result: click the "Select" action if available
+  try {
+    await page.getByText('Select', { exact: true }).click({ timeout: 3000 });
+    await waitForStableLoad(page);
+  } catch {
+    // Fallback: choose manual entry and close result dialog
+    const manualOption = page.getByLabel('No, enter company details manually', {
+      exact: true,
+    });
+    await manualOption.click({ timeout: 1000 }).catch(() => {});
+    await page.getByRole('button', { name: 'Close' }).click();
+    await waitForStableLoad(page);
+  }
 
   // VAT identification number
   await setRadioByLabel(


### PR DESCRIPTION
## Summary
- add fallback when no `Select` button after trade register search

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5abc2dfc832987753333aaeefa59