### PR TITLE
Handle missing KVK selection

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -376,6 +376,19 @@ test('End-to-end notification flow', async ({ page }) => {
       }
     }
     await waitForStableLoad(page);
+
+    // Ensure manual company entry is selected and provide company name
+    await setRadioByLabel(
+      page,
+      "Do you want to use the company's details from the Dutch trade register?",
+      'No, enter company details manually'
+    );
+    await waitForStableLoad(page);
+    await fillTextByLabel(
+      page,
+      'Company name',
+      requireEnv('SERVICE_RECIPIENT_COMPANY_NAME')
+    );
   }
 
   // VAT identification number


### PR DESCRIPTION
## Summary
- add fallback when no `Select` button after trade register search
- when falling back, identify the `Close` button via its tooltip text
- when falling back, re-select manual company entry and fill company name

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5abc2dfc832987753333aaeefa59