### PR TITLE
Click More search options before manual entry

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -377,6 +377,10 @@ test('End-to-end notification flow', async ({ page }) => {
     }
     await waitForStableLoad(page);
 
+    // Reveal additional options before manual company entry
+    await page.getByText('More search options', { exact: true }).click();
+    await waitForStableLoad(page);
+
     // Ensure manual company entry is selected and provide company name
     await setRadioByLabel(
       page,


### PR DESCRIPTION
## Summary
- click More search options before selecting manual trade-register entry

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6e6b2e6883298922e9ea83ed2cea