### PR TITLE
Ensure radio button selection matches exact text

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -118,6 +118,10 @@ async function selectMatOptionByLabel(page: Page, labelText: string, optionText:
   await selectMatOption(page, optionText);
 }
 
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 async function setRadioByLabel(
   page: Page,
   groupLabel: string | RegExp,
@@ -141,7 +145,8 @@ async function setRadioByLabel(
   }
 
   const optionLabel = container
-    .locator('label.radio-label', { hasText: optionText, exact: true })
+    .locator('label.radio-label')
+    .filter({ hasText: new RegExp(`^${escapeRegExp(optionText)}$`) })
     .first();
   await expect(optionLabel).toBeVisible({ timeout: 1000 });
   await optionLabel.click({ timeout: 1000 });


### PR DESCRIPTION
## Summary
- allow radio buttons to be targeted by exact option text within custom containers
- escape special characters when building regex for radio text match

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*
- `npx playwright install` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd78a598b883299f7c421670e4b754