### PR TITLE
feat: retry summary navigation

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -527,8 +527,18 @@ test('End-to-end notification flow', async ({ page }) => {
   );
 
   // Go to summary
-  await page.getByRole('button', { name: /Summary/i }).click();
-  await page.getByRole('button', { name: /Summary/i }).click();
+  const summaryButton = page.getByRole('button', { name: /Summary/i });
+  const declarationCheckbox = page.getByRole('checkbox', {
+    name: /With this I declare all questions have been answered truthfully\./,
+  });
+
+  await summaryButton.click();
+  try {
+    await expect(declarationCheckbox).toBeVisible({ timeout: 3000 });
+  } catch {
+    await summaryButton.click();
+    await expect(declarationCheckbox).toBeVisible({ timeout: 3000 });
+  }
 
   // SECTION 7 — Summary: confirm declaration and submit
   await setCheckboxByLabel(


### PR DESCRIPTION
## Summary
- add resilient navigation from section to summary by checking for the declaration checkbox and retrying if necessary

## Testing
- `npm test` *(fails: Executable doesn't exist; run `npx playwright install`)*
- `npx playwright install` *(fails: Download failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf20f488708329a886abe88dc0b70c