### PR TITLE
Handle submission modal before logout

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -546,9 +546,16 @@ test('End-to-end notification flow', async ({ page }) => {
     /With this I declare all questions have been answered truthfully\./
   );
   await page.getByRole('button', { name: /Submit notification/i }).click();
+  await waitForStableLoad(page);
+
+  // Confirmation dialog requires clicking OK before leaving
+  const okButton = page.getByRole('button', { name: 'OK' }).first();
+  if (await okButton.isVisible().catch(() => false)) {
+    await okButton.click();
+    await waitForStableLoad(page);
+  }
 
   // Logout
-  await waitForStableLoad(page);
   await page.getByText('Logout', { exact: false }).click();
   await waitForStableLoad(page);
 });


### PR DESCRIPTION
## Summary
- Acknowledge submission confirmation dialog by clicking OK before attempting to log out

## Testing
- `npm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell; install suggested)*
- `npx playwright install chromium` *(fails: Download failed, server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2799215083298db40afa118b116a