### PR TITLE
Handle OK dialog before logout more robustly

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -549,12 +549,14 @@ test('End-to-end notification flow', async ({ page }) => {
 
   // Confirmation dialog requires clicking OK before leaving
   const okButton = page.getByRole('button', { name: 'OK' }).first();
-  if (await okButton.isVisible().catch(() => false)) {
+  await expect(okButton).toBeVisible({ timeout: 10000 });
+  await okButton.click();
+  const logoutLink = page.getByText('Logout', { exact: false });
+  try {
+    await expect(logoutLink).toBeVisible({ timeout: 3000 });
+  } catch {
     await okButton.click();
-    await waitForStableLoad(page);
   }
-
-  // Logout
-  await page.getByText('Logout', { exact: false }).click();
+  await logoutLink.click();
   await waitForStableLoad(page);
 });


### PR DESCRIPTION
## Summary
- Ensure OK confirmation is visible and click it before logout
- Retry OK click if logout element doesn't appear within 3 seconds

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68bf30554c1c8329b5c1d7de34e0ab84